### PR TITLE
Bug fix: Handle error events triggered by http.get()

### DIFF
--- a/lib/lan2rf.coffee
+++ b/lib/lan2rf.coffee
@@ -49,7 +49,7 @@ class Lan2RF extends events.EventEmitter
 
   _processUrlJSONAsync: (request) ->
     return new Promise((resolve, reject) =>
-      http.get request, (res) =>
+      http.get(request, (res) =>
         body = ''
 
         res.on 'data', (chunk) =>
@@ -67,6 +67,11 @@ class Lan2RF extends events.EventEmitter
         res.on 'error', (e) =>
           @emit 'error', e
           reject e
+      ).on('error', (e) =>
+        console.log "Got error: #{e.message}"
+        @emit 'error', e
+        reject e
+      )
     )
 
   _periodicUpdateFromLan2RF: =>


### PR DESCRIPTION
For example, it is raised if the given address cannot be resolved, i.e. ENOENT, which happens occasionally in my environment when I switch of Wifi and the router is unreachable. This led to an unhandled exception and even caused my pimatic 0.9 to abnormally terminate.

See also example given in the API documentation https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_http_get_options_callback. Unfortunately, the explanation is buried in the depths of the API documentation. It can be found at: https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_http_request_options_callback: "If any error is encountered during the request (be that with DNS resolution, TCP level errors, or actual HTTP parse errors) an 'error' event is emitted on the returned request object. As with all 'error' events, if no listeners are registered the error will be thrown."
